### PR TITLE
Add support for ad-hoc commands.

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -42,6 +42,11 @@
 
 <h1>MotD Plugin Changelog</h1>
 
+<p><b>1.3.0</b> -- (tbd)</p>
+<ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-motd-plugin/issues/25'>Issue #25</a>] - Add support for MotD ad-hoc commands as defined in <a href="https://xmpp.org/extensions/xep-0133.html#delete-motd">XEP-0133: Service Administration</a></li>
+</ul>
+
 <p><b>1.2.5</b> -- November 15, 2024</p>
 <ul>
     <li>Requires Openfire 4.8.0 or later.</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
    <description>Allows admins to have a message sent to users each time they log in.</description>
    <author>Ryan Graham</author>
    <version>${project.version}</version>
-   <date>2024-11-15</date>
+   <date>2025-04-09</date>
    <minServerVersion>4.8.0</minServerVersion>
    <minJavaVersion>1.8</minJavaVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>motd</artifactId>
-    <version>1.2.6-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <name>Message of the Day Plugin</name>
     <description>Allows admins to have a message sent to users each time they log in.</description>
 

--- a/src/i18n/motd_i18n.properties
+++ b/src/i18n/motd_i18n.properties
@@ -11,3 +11,7 @@ motd.subject.missing=Please enter a subject.
 motd.message=Message
 motd.message.missing=Please enter a message.
 motd.button.save=Save Settings
+
+commands.admin.motd.setmotd.label=Set MotD
+commands.admin.motd.editmotd.label=Edit MotD
+commands.admin.motd.deletemotd.label=Delete MotD

--- a/src/java/org/jivesoftware/openfire/plugin/MotDPlugin.java
+++ b/src/java/org/jivesoftware/openfire/plugin/MotDPlugin.java
@@ -1,9 +1,28 @@
+/*
+ * Copyright (C) 2007-2017 Jive Software, 2017-2025 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jivesoftware.openfire.plugin;
 
 import java.io.File;
 import java.time.Duration;
 import java.util.TimerTask;
 
+import org.jivesoftware.openfire.plugin.commands.DeleteMotD;
+import org.jivesoftware.openfire.plugin.commands.EditMotD;
+import org.jivesoftware.openfire.plugin.commands.SetMotD;
 import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.TaskEngine;
 import org.jivesoftware.openfire.MessageRouter;
@@ -31,15 +50,26 @@ public class MotDPlugin implements Plugin {
 
    private MotDSessionEventListener listener = new MotDSessionEventListener();
 
+   private final SetMotD setMotD = new SetMotD();
+   private final EditMotD editMotD = new EditMotD();
+   private final DeleteMotD deleteMotD = new DeleteMotD();
+
    public void initializePlugin(PluginManager manager, File pluginDirectory) {
       serverAddress = new JID(XMPPServer.getInstance().getServerInfo().getXMPPDomain());
       router = XMPPServer.getInstance().getMessageRouter();
+
+      XMPPServer.getInstance().getAdHocCommandHandler().addCommand(setMotD);
+      XMPPServer.getInstance().getAdHocCommandHandler().addCommand(editMotD);
+      XMPPServer.getInstance().getAdHocCommandHandler().addCommand(deleteMotD);
 
       SessionEventDispatcher.addListener(listener);
    }
 
    public void destroyPlugin() {
       SessionEventDispatcher.removeListener(listener);
+      XMPPServer.getInstance().getAdHocCommandHandler().removeCommand(setMotD);
+      XMPPServer.getInstance().getAdHocCommandHandler().removeCommand(editMotD);
+      XMPPServer.getInstance().getAdHocCommandHandler().removeCommand(deleteMotD);
 
       listener = null;
       serverAddress = null;

--- a/src/java/org/jivesoftware/openfire/plugin/commands/DeleteMotD.java
+++ b/src/java/org/jivesoftware/openfire/plugin/commands/DeleteMotD.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2025 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.plugin.commands;
+
+import org.dom4j.Element;
+import org.jivesoftware.openfire.SessionManager;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.commands.AdHocCommand;
+import org.jivesoftware.openfire.commands.SessionData;
+import org.jivesoftware.openfire.plugin.MotDPlugin;
+import org.jivesoftware.util.LocaleUtils;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Implementation of the "Delete Message of the Day" ad-hoc command as defined in XEP-0133: Service Administration.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ * @see <a href="https://xmpp.org/extensions/xep-0133.html#delete-motd">XEP-0133: Service Administration</a>
+ */
+public class DeleteMotD extends AdHocCommand
+{
+    @Override
+    public String getCode()
+    {
+        return "http://jabber.org/protocol/admin#delete-motd";
+    }
+
+    @Override
+    public String getDefaultLabel()
+    {
+        return LocaleUtils.getLocalizedPluginString("motd", "commands.admin.motd.deletemotd.label");
+    }
+
+    @Override
+    public int getMaxStages(SessionData data)
+    {
+        return 0;
+    }
+
+    @Override
+    public void execute(SessionData sessionData, Element command)
+    {
+        final Locale preferredLocale = SessionManager.getInstance().getLocaleForSession(sessionData.getOwner());
+
+        Element note = command.addElement("note");
+
+        boolean requestError = false;
+        final MotDPlugin plugin = (MotDPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName("MotD (Message of the Day)").orElseThrow();
+        if (!plugin.isEnabled()) {
+            note.addAttribute( "type", "error" );
+            note.setText("A message of the day does not exist. You cannot delete it.");
+            requestError = true;
+        }
+
+        if ( requestError )
+        {
+            // We've collected all errors. Return without applying changes.
+            return;
+        }
+
+        // No errors.
+        plugin.setEnabled(false);
+
+        // Answer that the operation was successful
+        note.addAttribute("type", "info");
+        note.setText(LocaleUtils.getLocalizedString("commands.global.operation.finished.success", preferredLocale));
+    }
+
+    @Override
+    protected void addStageInformation(SessionData data, Element command)
+    {
+        // Do nothing since there are no stages
+    }
+
+    @Override
+    protected List<Action> getActions(SessionData data)
+    {
+        //Do nothing since there are no stages
+        return null;
+    }
+
+    @Override
+    protected Action getExecuteAction(SessionData data)
+    {
+        //Do nothing since there are no stages
+        return null;
+    }
+}

--- a/src/java/org/jivesoftware/openfire/plugin/commands/EditMotD.java
+++ b/src/java/org/jivesoftware/openfire/plugin/commands/EditMotD.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2025 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.plugin.commands;
+
+import org.dom4j.Element;
+import org.jivesoftware.openfire.SessionManager;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.commands.AdHocCommand;
+import org.jivesoftware.openfire.commands.SessionData;
+import org.jivesoftware.openfire.plugin.MotDPlugin;
+import org.jivesoftware.util.LocaleUtils;
+import org.xmpp.forms.DataForm;
+import org.xmpp.forms.FormField;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Implementation of the "Edit Message of the Day" ad-hoc command as defined in XEP-0133: Service Administration.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ * @see <a href="https://xmpp.org/extensions/xep-0133.html#edit-motd">XEP-0133: Service Administration</a>
+ */
+public class EditMotD extends AdHocCommand
+{
+    @Override
+    public String getCode()
+    {
+        return "http://jabber.org/protocol/admin#edit-motd";
+    }
+
+    @Override
+    public String getDefaultLabel()
+    {
+        return LocaleUtils.getLocalizedPluginString("motd", "commands.admin.motd.editmotd.label");
+    }
+
+    @Override
+    public int getMaxStages(SessionData data)
+    {
+        return 1;
+    }
+
+    @Override
+    public void execute(SessionData sessionData, Element command)
+    {
+        final Locale preferredLocale = SessionManager.getInstance().getLocaleForSession(sessionData.getOwner());
+
+        Element note = command.addElement("note");
+
+        Map<String, List<String>> data = sessionData.getData();
+
+        boolean requestError = false;
+        final MotDPlugin plugin = (MotDPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName("MotD (Message of the Day)").orElseThrow();
+        if (!plugin.isEnabled()) {
+            note.addAttribute( "type", "error" );
+            note.setText("A message of the day does not yet exist. If you intend to add a message of the day, use the 'Add Message of the Day' command instead.");
+            requestError = true;
+        }
+
+        final List<String> motd = data.get("motd");
+        if (motd == null || motd.isEmpty()) {
+            note.addAttribute( "type", "error" );
+            note.setText("Please provide text for the message of the day. If you intend to remove the message of the day, use the 'Delete Message of the Day' command instead.");
+            requestError = true;
+        }
+
+        if ( requestError )
+        {
+            // We've collected all errors. Return without applying changes.
+            return;
+        }
+
+        // No errors.
+        plugin.setMessage(String.join(System.lineSeparator(), motd));
+
+        // Answer that the operation was successful
+        note.addAttribute("type", "info");
+        note.setText(LocaleUtils.getLocalizedString("commands.global.operation.finished.success", preferredLocale));
+    }
+
+    @Override
+    protected void addStageInformation(SessionData data, Element command)
+    {
+        final MotDPlugin plugin = (MotDPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName("MotD (Message of the Day)").orElseThrow();
+
+        DataForm form = new DataForm(DataForm.Type.form);
+        form.setTitle("Editing the Message of the Day");
+        form.addInstruction("Fill out this form to edit the message of the day.");
+
+        FormField field = form.addField();
+        field.setType(FormField.Type.hidden);
+        field.setVariable("FORM_TYPE");
+        field.addValue("http://jabber.org/protocol/admin");
+
+        field = form.addField();
+        field.setType(FormField.Type.text_multi);
+        field.setLabel("Message of the Day");
+        field.setVariable("motd");
+
+        if (plugin.isEnabled() && plugin.getMessage() != null) {
+            for (final String part : plugin.getMessage().split(System.lineSeparator())) {
+                field.addValue(part);
+            }
+        }
+
+        // Add the form to the command
+        command.add(form.getElement());
+    }
+
+    @Override
+    protected List<Action> getActions(SessionData data)
+    {
+        return Collections.singletonList(Action.complete);
+    }
+
+    @Override
+    protected Action getExecuteAction(SessionData data)
+    {
+        return Action.complete;
+    }
+}

--- a/src/java/org/jivesoftware/openfire/plugin/commands/EditMotD.java
+++ b/src/java/org/jivesoftware/openfire/plugin/commands/EditMotD.java
@@ -87,7 +87,7 @@ public class EditMotD extends AdHocCommand
         }
 
         // No errors.
-        plugin.setMessage(String.join(System.lineSeparator(), motd));
+        plugin.setMessage(String.join("\r\n", motd));
 
         // Answer that the operation was successful
         note.addAttribute("type", "info");
@@ -114,7 +114,7 @@ public class EditMotD extends AdHocCommand
         field.setVariable("motd");
 
         if (plugin.isEnabled() && plugin.getMessage() != null) {
-            for (final String part : plugin.getMessage().split(System.lineSeparator())) {
+            for (final String part : plugin.getMessage().split("\r\n")) {
                 field.addValue(part);
             }
         }

--- a/src/java/org/jivesoftware/openfire/plugin/commands/SetMotD.java
+++ b/src/java/org/jivesoftware/openfire/plugin/commands/SetMotD.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2025 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.openfire.plugin.commands;
+
+import org.dom4j.Element;
+import org.jivesoftware.openfire.SessionManager;
+import org.jivesoftware.openfire.XMPPServer;
+import org.jivesoftware.openfire.commands.AdHocCommand;
+import org.jivesoftware.openfire.commands.SessionData;
+import org.jivesoftware.openfire.plugin.MotDPlugin;
+import org.jivesoftware.util.LocaleUtils;
+import org.xmpp.forms.DataForm;
+import org.xmpp.forms.FormField;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Implementation of the "Set Message of the Day" ad-hoc command as defined in XEP-0133: Service Administration.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ * @see <a href="https://xmpp.org/extensions/xep-0133.html#set-motd">XEP-0133: Service Administration</a>
+ */
+public class SetMotD extends AdHocCommand
+{
+    @Override
+    public String getCode()
+    {
+        return "http://jabber.org/protocol/admin#set-motd";
+    }
+
+    @Override
+    public String getDefaultLabel()
+    {
+        return LocaleUtils.getLocalizedPluginString("motd", "commands.admin.motd.setmotd.label");
+    }
+
+    @Override
+    public int getMaxStages(SessionData data)
+    {
+        return 1;
+    }
+
+    @Override
+    public void execute(SessionData sessionData, Element command)
+    {
+        final Locale preferredLocale = SessionManager.getInstance().getLocaleForSession(sessionData.getOwner());
+
+        Element note = command.addElement("note");
+
+        Map<String, List<String>> data = sessionData.getData();
+
+        boolean requestError = false;
+        final MotDPlugin plugin = (MotDPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName("MotD (Message of the Day)").orElseThrow();
+        if (plugin.isEnabled()) {
+            note.addAttribute( "type", "error" );
+            note.setText("A message of the day is already set. If you intend to edit the message of the day, use the 'Edit Message of the Day' command instead.");
+            requestError = true;
+        }
+
+        final List<String> motd = data.get("motd");
+        if (motd == null || motd.isEmpty()) {
+            note.addAttribute( "type", "error" );
+            note.setText("Please provide text for the message of the day. If you intend to remove the message of the day, use the 'Delete Message of the Day' command instead.");
+            requestError = true;
+        }
+
+        if ( requestError )
+        {
+            // We've collected all errors. Return without applying changes.
+            return;
+        }
+
+        // No errors.
+        plugin.setMessage(String.join(System.lineSeparator(), motd));
+        plugin.setEnabled(true);
+
+        // Answer that the operation was successful
+        note.addAttribute("type", "info");
+        note.setText(LocaleUtils.getLocalizedString("commands.global.operation.finished.success", preferredLocale));
+    }
+
+    @Override
+    protected void addStageInformation(SessionData data, Element command)
+    {
+        DataForm form = new DataForm(DataForm.Type.form);
+        form.setTitle("Setting the Message of the Day");
+        form.addInstruction("Fill out this form to set the message of the day.");
+
+        FormField field = form.addField();
+        field.setType(FormField.Type.hidden);
+        field.setVariable("FORM_TYPE");
+        field.addValue("http://jabber.org/protocol/admin");
+
+        field = form.addField();
+        field.setType(FormField.Type.text_multi);
+        field.setLabel("Message of the Day");
+        field.setVariable("motd");
+
+        // Add the form to the command
+        command.add(form.getElement());
+    }
+
+    @Override
+    protected List<Action> getActions(SessionData data)
+    {
+        return Collections.singletonList(Action.complete);
+    }
+
+    @Override
+    protected Action getExecuteAction(SessionData data)
+    {
+        return AdHocCommand.Action.complete;
+    }
+}

--- a/src/java/org/jivesoftware/openfire/plugin/commands/SetMotD.java
+++ b/src/java/org/jivesoftware/openfire/plugin/commands/SetMotD.java
@@ -87,7 +87,7 @@ public class SetMotD extends AdHocCommand
         }
 
         // No errors.
-        plugin.setMessage(String.join(System.lineSeparator(), motd));
+        plugin.setMessage(String.join("\r\n", motd));
         plugin.setEnabled(true);
 
         // Answer that the operation was successful


### PR DESCRIPTION
XEP-0133 defines a number of MotD related ad-hoc commands. This commit adds support for those.

The lack of i18n is intentional - I couldn't get that to work.