### PR TITLE
fixes #27: compatibility with Openfire 5.0.0

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,6 +44,8 @@
 
 <p><b>1.3.0</b> -- (tbd)</p>
 <ul>
+    <li>Requires Java 11 or later</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-motd-plugin/issues/27'>Issue #27</a>] - Fix compatibility with Openfire 5.0.0</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-motd-plugin/issues/25'>Issue #25</a>] - Add support for MotD ad-hoc commands as defined in <a href="https://xmpp.org/extensions/xep-0133.html#delete-motd">XEP-0133: Service Administration</a></li>
 </ul>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,9 +6,9 @@
    <description>Allows admins to have a message sent to users each time they log in.</description>
    <author>Ryan Graham</author>
    <version>${project.version}</version>
-   <date>2025-04-09</date>
+   <date>2025-07-02</date>
    <minServerVersion>4.8.0</minServerVersion>
-   <minJavaVersion>1.8</minJavaVersion>
+   <minJavaVersion>11</minJavaVersion>
 
    <adminconsole>
       <tab id="tab-users">

--- a/src/web/motd-form.jsp
+++ b/src/web/motd-form.jsp
@@ -22,7 +22,7 @@ errorPage="error.jsp"%>
     final Cookie csrfCookie = CookieUtils.getCookie( request, "csrf" );
     final String csrfParam = ParamUtils.getParameter( request, "csrf" );
 
-    final MotDPlugin plugin = (MotDPlugin) XMPPServer.getInstance().getPluginManager().getPlugin( "motd" );
+    final MotDPlugin plugin = (MotDPlugin) XMPPServer.getInstance().getPluginManager().getPluginByName( "MotD (Message of the Day)" ).orElseThrow();
 
     final Map<String, String> errors = new HashMap<>();
     if ( save )
@@ -32,12 +32,12 @@ errorPage="error.jsp"%>
             errors.put( "csrf", "CSRF Failure!" );
         }
 
-        if ( motdSubject == null || motdSubject.trim().length() < 1 )
+        if ( motdSubject == null || motdSubject.trim().isEmpty())
         {
             errors.put( "missingMotdSubject", "missingMotdSubject" );
         }
 
-        if ( motdMessage == null || motdMessage.trim().length() < 1 )
+        if ( motdMessage == null || motdMessage.trim().isEmpty())
         {
             errors.put( "missingMotdMessage", "missingMotdMessage" );
         }


### PR DESCRIPTION
This commit replaces usage of an Openfire method that was removed in Openfire 5.0.0 with one that was introduced in 4.4.0.

The minimum server requirement remains at Openfire 4.8.0, but the minimum required version of Java has been bumped from 8 to 11.